### PR TITLE
fixes rendering issue in coverall.io portal

### DIFF
--- a/Coveralls.Lib/CoverageFile.cs
+++ b/Coveralls.Lib/CoverageFile.cs
@@ -20,6 +20,7 @@ namespace Coveralls.Lib
 
             set
             {
+                _coverage = null;
                 if (string.IsNullOrEmpty(value))
                 {
                     _sourceLines = new List<string>();
@@ -39,18 +40,24 @@ namespace Coveralls.Lib
             }
         }
 
+        private int?[] _coverage;
+
         [JsonProperty("coverage")]
         public int?[] Coverage
         {
             get
             {
-                var length = 1;
-                if (_sourceLines != null) length = _sourceLines.Count;
-                else if (_lineCoverage.Count > 0) length = _lineCoverage.Max(c => c.Key);
+                if (_coverage == null)
+                {
+                    var length = 1;
+                    if (_sourceLines != null) length = _sourceLines.Count;
+                    else if (_lineCoverage.Count > 0) length = _lineCoverage.Max(c => c.Key);
 
-                return Enumerable.Range(0, length)
-                    .Select(index => _lineCoverage.ContainsKey(index) ? (int?)_lineCoverage[index] : null)
-                    .ToArray();
+                    _coverage = Enumerable.Range(1, length)
+                        .Select(index => _lineCoverage.ContainsKey(index) ? (int?)_lineCoverage[index] : null)
+                        .ToArray();
+                }
+                return _coverage;
             }
         }
 

--- a/Coveralls.Tests/CoverageFileTests.cs
+++ b/Coveralls.Tests/CoverageFileTests.cs
@@ -68,8 +68,8 @@ namespace Coveralls.Tests
 
             coverageFile.Record(1, 1);
 
-            coverageFile.Coverage[0].Should().Be(null);
-            coverageFile.Coverage[1].Should().Be(1);
+            coverageFile.Coverage[0].Should().Be(1);
+            coverageFile.Coverage[1].Should().Be(null);
             coverageFile.Coverage[2].Should().Be(null);
         }
 
@@ -82,10 +82,10 @@ namespace Coveralls.Tests
             coverageFile.Source = sourceText;
 
             coverageFile.Record(1, 1);
-            coverageFile.Record(2, 3);
+            coverageFile.Record(3, 3);
 
-            coverageFile.Coverage[0].Should().Be(null);
-            coverageFile.Coverage[1].Should().Be(1);
+            coverageFile.Coverage[0].Should().Be(1);
+            coverageFile.Coverage[1].Should().Be(null);
             coverageFile.Coverage[2].Should().Be(3);
         }
 

--- a/Coveralls.Tests/OpenCoverParserTests.cs
+++ b/Coveralls.Tests/OpenCoverParserTests.cs
@@ -71,10 +71,17 @@ namespace Coveralls.Tests
             var parser = new OpenCoverParser(fileSystem) { Report = TestHelpers.LoadResourceXml("Coveralls.Tests.Files.OpenCover.SingleFileCoverage.xml") };
 
             var coverageFile = parser.Generate().First();
+
+            var lines = coverageFile.Source.Split(new[] {'\n'});
+
+            lines[11].Trim().Should().Be("{");
+            coverageFile.Coverage[11].Should().Be(16);
+            lines[12].Trim().Should().Be("if (string.IsNullOrEmpty(date))");
             coverageFile.Coverage[12].Should().Be(16);
-            coverageFile.Coverage[13].Should().Be(16);
-            coverageFile.Coverage[22].Should().Be(3);
-            coverageFile.Coverage[24].Should().Be(11);
+            lines[19].Trim().Should().Be("hour = 0;");
+            coverageFile.Coverage[19].Should().Be(3);
+            lines[24].Trim().Should().Be("while (time.Length < 4)");
+            coverageFile.Coverage[24].Should().Be(15);
         }
     }
 }


### PR DESCRIPTION
Files should be treated as starting at line 1 rather than 0 as the coverage for a line is being associated with the next line below - this offset causes the rendering on coveralls portal to look odd (e.g. https://coveralls.io/files/421332626)

When adjusted the rendering is now correctly aligned (see https://coveralls.io/files/426552107) 
