### PR TITLE
Source digest enhancements

### DIFF
--- a/Coveralls.Lib/CoverageFile.cs
+++ b/Coveralls.Lib/CoverageFile.cs
@@ -19,7 +19,7 @@ namespace Coveralls
         [JsonProperty("source", NullValueHandling = NullValueHandling.Ignore)]
         public string Source
         {
-            get { return Digest ? null : _source; }
+            get { return _source; }
             set
             {
                 _coverage = null;
@@ -42,38 +42,7 @@ namespace Coveralls
         }
 
         [JsonProperty("source_digest", NullValueHandling = NullValueHandling.Ignore)]
-        public string SourceDigest
-        {
-            get
-            {
-                if (!Digest) return null;
-
-                var hash = MD5.Create();
-                var md5Digest = hash.ComputeHash(Encoding.UTF8.GetBytes(_source));
-
-                var builder = new StringBuilder();
-                foreach (var b in md5Digest) 
-                {
-                    builder.Append(b.ToString("x2"));
-                }
-                return builder.ToString();
-            }
-        }
-
-        private bool _digest = true;
-
-        [JsonIgnore]
-        public bool Digest
-        { 
-            get 
-            { 
-                return _digest; 
-            }
-            set 
-            { 
-                _digest = value; 
-            }
-        }
+        public string SourceDigest { get; set; }
 
         private IEnumerable<int?> _coverage;
 

--- a/Coveralls.Lib/CoverallsBootstrap.cs
+++ b/Coveralls.Lib/CoverallsBootstrap.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
 using System.Xml.Linq;
 
 namespace Coveralls
@@ -109,10 +112,23 @@ namespace Coveralls
 
                     if (_opts.SendFullSources)
                     {
-                        // Send full source instead of MD5 digest
                         foreach (var coverageFile in coverageFileList)
                         {
-                            coverageFile.Digest = false;
+                            coverageFile.Source = FileSystem.ReadFileText(coverageFile.Path);
+                        }
+                    }
+                    else
+                    {
+                        foreach (var coverageFile in coverageFileList)
+                        {
+                            var hash = FileSystem.ComputeHash(coverageFile.Path);
+
+                            var builder = new StringBuilder();
+                            foreach (var b in hash)
+                            {
+                                builder.Append(b.ToString("x2"));
+                            }
+                            coverageFile.SourceDigest = builder.ToString();
                         }
                     }
 
@@ -154,9 +170,9 @@ namespace Coveralls
             switch (_opts.Parser)
             {
                 case ParserType.OpenCover:
-                    return new OpenCoverParser(FileSystem);
+                    return new OpenCoverParser();
             }
-            return new OpenCoverParser(FileSystem);
+            return new OpenCoverParser();
         }
 
         public CoverallsData GetData()

--- a/Coveralls.Lib/CoverallsBootstrap.cs
+++ b/Coveralls.Lib/CoverallsBootstrap.cs
@@ -37,7 +37,7 @@ namespace Coveralls
 
         public void Dispose()
         {
-            _repository.Dispose();
+            if(_repository != null) _repository.Dispose();
             GC.SuppressFinalize(this);
         }
 
@@ -132,8 +132,7 @@ namespace Coveralls
                         }
                     }
 
-                    if (coverageFileList.Any())
-                        this._files = coverageFileList;
+                    _files = coverageFileList;
                 }
 
                 return _files;

--- a/Coveralls.Lib/IFileSystem.cs
+++ b/Coveralls.Lib/IFileSystem.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -9,5 +10,6 @@ namespace Coveralls
     public interface IFileSystem
     {
         string ReadFileText(string path);
+        byte[] ComputeHash(string path);
     }
 }

--- a/Coveralls.Lib/Parser/BaseParser.cs
+++ b/Coveralls.Lib/Parser/BaseParser.cs
@@ -7,16 +7,6 @@ namespace Coveralls
     [ExcludeFromCodeCoverage]
     public class BaseParser : ICoverageParser
     {
-        private IFileSystem _fileSystem;
-        protected IFileSystem FileSystem
-        {
-            get { return _fileSystem; }
-        }
-        public BaseParser(IFileSystem fileSystem)
-        {
-            _fileSystem = fileSystem;
-        }
-
         public XDocument Report { get; set; }
 
         public virtual IEnumerable<CoverageFile> Generate()

--- a/Coveralls.Lib/Parser/OpenCoverParser.cs
+++ b/Coveralls.Lib/Parser/OpenCoverParser.cs
@@ -7,7 +7,7 @@ namespace Coveralls
 {
     public class OpenCoverParser : BaseParser
     {
-        public OpenCoverParser(IFileSystem fileSystem) : base(fileSystem)
+        public OpenCoverParser()
         {
         }
 
@@ -29,8 +29,7 @@ namespace Coveralls
 
                     var coverageFile = new CoverageFile
                     {
-                        Path = fullPath.ToUnixPath(),
-                        Source = FileSystem.ReadFileText(fullPath)
+                        Path = fullPath.ToUnixPath()
                     };
 
                     foreach (var @class in module.XPathSelectElements("./Classes/Class"))

--- a/Coveralls.Tests/CoverageFileTests.cs
+++ b/Coveralls.Tests/CoverageFileTests.cs
@@ -13,33 +13,10 @@ namespace Coveralls.Tests
     public class CoverageFileTests
     {
         [Test]
-        public void Source_DigestTrue_ReturnsNull()
-        {
-            var sourceText = "Line1\r\nLine2\r\nLine3";
-            var coverageFile = new CoverageFile();
-            coverageFile.Digest = true;
-            coverageFile.Source = sourceText;
-
-            coverageFile.Source.Should().BeNull();
-        }
-
-        [Test]
-        public void SourceDigest_DigestFalse_ReturnsNull()
-        {
-            var sourceText = "Line1\r\nLine2\r\nLine3";
-            var coverageFile = new CoverageFile();
-            coverageFile.Digest = false;
-            coverageFile.Source = sourceText;
-
-            coverageFile.SourceDigest.Should().BeNull();
-        }
-
-        [Test]
         public void Source_SetToGet_ConvertsToUnixLineBreaks()
         {
             var sourceText = "Line1\r\nLine2\r\nLine3";
             var coverageFile = new CoverageFile();
-            coverageFile.Digest = false;
 
             coverageFile.Source = sourceText;
 
@@ -51,7 +28,6 @@ namespace Coveralls.Tests
         {
             var sourceText = "Line1\nLine2\nLine3";
             var coverageFile = new CoverageFile();
-            coverageFile.Digest = false;
 
             coverageFile.Source = sourceText;
 

--- a/Coveralls.Tests/CoverallsBootstrapTests.cs
+++ b/Coveralls.Tests/CoverallsBootstrapTests.cs
@@ -143,20 +143,7 @@ namespace Coveralls.Tests
         }
 
         [Test]
-        public void CoverageFiles_NoReportFile_ThrowsException()
-        {
-            var fileSystem = Substitute.For<IFileSystem>();
-            fileSystem.ReadFileText("").ReturnsForAnyArgs(a => null);
-
-            var opts = Substitute.For<ICommandOptions>();
-            var coveralls = new CoverallsBootstrap(opts);
-            coveralls.FileSystem = fileSystem;
-
-            coveralls.CoverageFiles.Should().BeNull();
-        }
-
-        [Test]
-        public void CoverageFiles_EmptyReportFile_CoverageFilesIsNull()
+        public void CoverageFiles_EmptyReportFile_CoverageFilesIsEmpty()
         {
             var fileSystem = Substitute.For<IFileSystem>();
             fileSystem.ReadFileText("").ReturnsForAnyArgs("");
@@ -165,7 +152,7 @@ namespace Coveralls.Tests
             var coveralls = new CoverallsBootstrap(opts);
             coveralls.FileSystem = fileSystem;
 
-            coveralls.CoverageFiles.Should().BeNull();
+            coveralls.CoverageFiles.Should().BeEmpty();
         }
 
         [Test]

--- a/Coveralls.Tests/OpenCoverParserTests.cs
+++ b/Coveralls.Tests/OpenCoverParserTests.cs
@@ -12,8 +12,7 @@ namespace Coveralls.Tests
         [Test]
         public void EmptyReport_NoResults()
         {
-            var fileSystem = Substitute.For<IFileSystem>();
-            var parser = new OpenCoverParser(fileSystem) { Report = TestHelpers.LoadResourceXml("Coveralls.Tests.Files.OpenCover.EmptyReport.xml") };
+            var parser = new OpenCoverParser() { Report = TestHelpers.LoadResourceXml("Coveralls.Tests.Files.OpenCover.EmptyReport.xml") };
 
             var results = parser.Generate();
 
@@ -23,8 +22,7 @@ namespace Coveralls.Tests
         [Test]
         public void SingleFileReport_OneCoverageFile()
         {
-            var fileSystem = Substitute.For<IFileSystem>();
-            var parser = new OpenCoverParser(fileSystem) { Report = TestHelpers.LoadResourceXml("Coveralls.Tests.Files.OpenCover.SingleFileCoverage.xml") };
+            var parser = new OpenCoverParser() { Report = TestHelpers.LoadResourceXml("Coveralls.Tests.Files.OpenCover.SingleFileCoverage.xml") };
 
             var results = parser.Generate();
 
@@ -34,8 +32,7 @@ namespace Coveralls.Tests
         [Test]
         public void SingleFileReport_CoverageFile_ShouldHaveCorrectFileName()
         {
-            var fileSystem = Substitute.For<IFileSystem>();
-            var parser = new OpenCoverParser(fileSystem) { Report = TestHelpers.LoadResourceXml("Coveralls.Tests.Files.OpenCover.SingleFileCoverage.xml") };
+            var parser = new OpenCoverParser() { Report = TestHelpers.LoadResourceXml("Coveralls.Tests.Files.OpenCover.SingleFileCoverage.xml") };
 
             var coverageFile = parser.Generate().First();
 
@@ -43,29 +40,13 @@ namespace Coveralls.Tests
         }
 
         [Test]
-        public void SingleFileReport_CoverageFile_LineCountShouldBeCorrect()
-        {
-            var fileSystem = Substitute.For<IFileSystem>();
-            fileSystem.ReadFileText(@"c:\src\SymSharp\Symitar\Utilities.cs")
-                .Returns(TestHelpers.LoadResourceText("Coveralls.Tests.Files.Utilities.cs"));
-            var parser = new OpenCoverParser(fileSystem) { Report = TestHelpers.LoadResourceXml("Coveralls.Tests.Files.OpenCover.SingleFileCoverage.xml") };
-            
-            var coverageFile = parser.Generate().First();
-            coverageFile.Digest = false;
-
-            coverageFile.Source.Split('\n').Length.Should().Be(140);
-        }
-
-        [Test]
         public void SingleFileReport_CoverageFile_LineCoverageShouldMatchForSomeLines()
         {
-            var fileSystem = Substitute.For<IFileSystem>();
-            fileSystem.ReadFileText(@"c:\src\SymSharp\Symitar\Utilities.cs")
-                .Returns(TestHelpers.LoadResourceText("Coveralls.Tests.Files.Utilities.cs"));
-            var parser = new OpenCoverParser(fileSystem) { Report = TestHelpers.LoadResourceXml("Coveralls.Tests.Files.OpenCover.SingleFileCoverage.xml") };
+            var parser = new OpenCoverParser() { Report = TestHelpers.LoadResourceXml("Coveralls.Tests.Files.OpenCover.SingleFileCoverage.xml") };
 
             var coverageFile = parser.Generate().First();
-            coverageFile.Digest = false;
+
+            coverageFile.Source = TestHelpers.LoadResourceText("Coveralls.Tests.Files.Utilities.cs");
 
             var lines = coverageFile.Source.Split(new[] {'\n'});
 

--- a/coveralls.net/LocalFileSystem.cs
+++ b/coveralls.net/LocalFileSystem.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Security.Cryptography;
 using Coveralls;
 
 namespace Coveralls.Net
@@ -7,15 +8,32 @@ namespace Coveralls.Net
     {
         public string ReadFileText(string path)
         {
-            if (!Path.IsPathRooted(path))
-                path = Directory.GetCurrentDirectory() + "\\" + path;
+            var rootedPath = RootedPath(path);
 
-            if (File.Exists(path))
+            if (File.Exists(rootedPath))
             {
-                var content = File.ReadAllText(path);
+                var content = File.ReadAllText(rootedPath);
                 return content;
             }
             return null;
+        }
+
+        public byte[] ComputeHash(string path)
+        {
+            var rootedPath = RootedPath(path);
+
+            using (var md5 = MD5.Create())
+            {
+                using (var stream = new BufferedStream(File.OpenRead(rootedPath), 1200000))
+                {
+                    return md5.ComputeHash(stream);
+                }
+            }
+        }
+
+        private string RootedPath(string path)
+        {
+            return Path.IsPathRooted(path) ? path : string.Format(@"{0}\{1}", Directory.GetCurrentDirectory(), path);
         }
     }
 }

--- a/coveralls.net/Program.cs
+++ b/coveralls.net/Program.cs
@@ -21,6 +21,7 @@ namespace Coveralls.Net
             {
                 Console.WriteLine(Resources.GenericError);
                 Console.WriteLine(e.Message);
+                Console.WriteLine(e.StackTrace);
                 Environment.Exit(1);
             }
         }


### PR DESCRIPTION
- Creating hash computation on IFileSystem for quicker MD5 hashing of files
- Source loading now responsibility of CoverallsBootstrap
- Removing digest on/off code from CoverageFile itself
- Removing FileSystem from parsers as it is no longer needed there
