### PR TITLE
Add committer info to GitData

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ package
 TestResult.xml
 results.xml
 coverage.xml
+
+# Ignore local Visual Studio settings
+.vs/

--- a/Coveralls.Lib/AppVeyorGit.cs
+++ b/Coveralls.Lib/AppVeyorGit.cs
@@ -33,6 +33,10 @@ namespace Coveralls
                         AuthorEmail = Environment.GetEnvironmentVariable("APPVEYOR_REPO_COMMIT_AUTHOREMAIL"),
                         PullRequestId = Environment.GetEnvironmentVariable("APPVEYOR_PULL_REQUEST_NUMBER")
                     };
+
+                    // AppVeyor only supplies author data
+                    _head.Committer = _head.Author;
+                    _head.CommitterEmail = _head.AuthorEmail;
                 }
                 return _head;
             }

--- a/Coveralls.Lib/GitData.cs
+++ b/Coveralls.Lib/GitData.cs
@@ -26,6 +26,12 @@ namespace Coveralls
         [JsonProperty("author_email", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string AuthorEmail { get; set; }
 
+        [JsonProperty("committer_name", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Committer { get; set; }
+
+        [JsonProperty("committer_email", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string CommitterEmail { get; set; }
+
         [JsonProperty("message", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string Message { get; set; }
 

--- a/Coveralls.Lib/LocalGit.cs
+++ b/Coveralls.Lib/LocalGit.cs
@@ -50,7 +50,9 @@ namespace Coveralls
                         Id = c.Id.Sha,
                         Message = c.Message,
                         Author = c.Author.Name,
-                        AuthorEmail = c.Author.Email
+                        AuthorEmail = c.Author.Email,
+                        Committer = c.Committer.Name,
+                        CommitterEmail = c.Committer.Email
                     });
             }
         }

--- a/Coveralls.Tests/AppVeyorGitTests.cs
+++ b/Coveralls.Tests/AppVeyorGitTests.cs
@@ -74,6 +74,8 @@ namespace Coveralls.Tests
             git.Head.Message.Should().Be("Initial commit");
             git.Head.Author.Should().Be("jdeering");
             git.Head.AuthorEmail.Should().Be("jason@deering.me");
+            git.Head.Committer.Should().Be("jdeering");
+            git.Head.CommitterEmail.Should().Be("jason@deering.me");
         }
 
         [Test]


### PR DESCRIPTION
Currently, only the author name and email is stored. Coveralls then
displays nothing on the "Committed by" field. This change adds committer
name and email (for AppVeyor they are copied from author name/email since
AppVeyor does not provide committer data).

Reference: https://docs.coveralls.io/api-reference

Also adds the .vs settings folder to .gitignore.